### PR TITLE
Fixed vortex api failing to build on linux.

### DIFF
--- a/lib/util/Steam.js
+++ b/lib/util/Steam.js
@@ -5,10 +5,9 @@ const Registry = require("winreg");
 const fs = require("./fs");
 const log_1 = require("./log");
 const storeHelper_1 = require("./storeHelper");
-const electron_1 = require("electron");
 const path = require("path");
 const simple_vdf_1 = require("simple-vdf");
-const app = (electron_1.remote !== undefined) ? electron_1.remote.app : electron_1.app;
+const {homedir} = require("os");
 class GameNotFound extends Error {
     constructor(search) {
         super(`game not found: ${search}`);
@@ -57,7 +56,7 @@ class Steam {
             });
         }
         else {
-            this.mBaseFolder = Promise.resolve(path.resolve(app.getPath('home'), '.steam', 'steam'));
+            this.mBaseFolder = Promise.resolve(path.resolve(homedir(), '.steam', 'steam'));
         }
     }
     /**


### PR DESCRIPTION
In linux the fallback line fails with app is undefined. Changed the app.getPath('home') call to instead use nodes os.homedir() function.