### PR TITLE
Adds ability to override extractInfo game name in config

### DIFF
--- a/bin/extractInfo.js
+++ b/bin/extractInfo.js
@@ -17,7 +17,7 @@ function extractExtensionInfo(extPath) {
   const pkgInfo = JSON.parse(fs.readFileSync(path.join(extPath, 'package.json')).toString());
 
   return {
-    name: transformName(pkgInfo.name),
+    name: (pkgInfo.config && pkgInfo.config.game) ? `Game: ${pkgInfo.config.game}` : transformName(pkgInfo.name),
     author: pkgInfo.author,
     version: pkgInfo.version,
     description: pkgInfo.description,


### PR DESCRIPTION
The current logic of `extractInfo` will result in slightly dodgy looking names for games with multiple words in the title (since the `game-gamenamehere` form doesn't have the spaces).

This just adds the ability to **optionally** override the name used in the generated `info.json` by setting a `config.game` key in `package.json`. It will fall back to default behaviour if that's not set.

I've used this locally and it works, but let me know if it needs any changes.