### PR TITLE
Add `id` to parsed details for predictability

### DIFF
--- a/bin/extractInfo.js
+++ b/bin/extractInfo.js
@@ -17,6 +17,7 @@ function extractExtensionInfo(extPath) {
   const pkgInfo = JSON.parse(fs.readFileSync(path.join(extPath, 'package.json')).toString());
 
   return {
+    id: pkgInfo.name,
     name: (pkgInfo.config && pkgInfo.config.game) ? `Game: ${pkgInfo.config.game}` : transformName(pkgInfo.name),
     author: pkgInfo.author,
     version: pkgInfo.version,

--- a/bin/extractInfo.js
+++ b/bin/extractInfo.js
@@ -17,7 +17,7 @@ function extractExtensionInfo(extPath) {
   const pkgInfo = JSON.parse(fs.readFileSync(path.join(extPath, 'package.json')).toString());
 
   return {
-    id: pkgInfo.name,
+    id: (pkgInfo.config && pkgInfo.config.id) ? pkgInfo.config.id : undefined,
     name: (pkgInfo.config && pkgInfo.config.game) ? `Game: ${pkgInfo.config.game}` : transformName(pkgInfo.name),
     author: pkgInfo.author,
     version: pkgInfo.version,


### PR DESCRIPTION
Pulling the extension details from extension code in Vortex is currently pretty hard for Nexus-installed extensions since the installation directory is based on the `basename` of the installation path.

This change adds the `id` field to the extracted `info.json` (using the package name) to make it a bit more predictable.

Let me know if it needs other changes, or if this would break things I'm not thinking of 👍 