### PR TITLE
Add optional extraction of namespace from config

### DIFF
--- a/bin/extractInfo.js
+++ b/bin/extractInfo.js
@@ -18,6 +18,7 @@ function extractExtensionInfo(extPath) {
 
   return {
     name: (pkgInfo.config && pkgInfo.config.game) ? `Game: ${pkgInfo.config.game}` : transformName(pkgInfo.name),
+    namespace: (pkgInfo.config && pkgInfo.config.namespace) ? pkgInfo.config.namespace : undefined,
     author: pkgInfo.author,
     version: pkgInfo.version,
     description: pkgInfo.description,


### PR DESCRIPTION
This adds optional, opt-in namespace extraction to go along with the [new namespace changes](https://github.com/Nexus-Mods/Vortex/commit/70dd0e32a90e8af5bd95a2b3593c8cc6d9c426ee).

As always, let me know if there's a problem with this or if it's not how it's supposed to work.