### PR TITLE
Add another option for name extraction

### DIFF
--- a/bin/extractInfo.js
+++ b/bin/extractInfo.js
@@ -7,6 +7,16 @@ function transformName(input) {
   return input.charAt(0).toUpperCase() + input.substr(1).replace(/-([a-z])/g, (match, m1) => ' ' + m1.toUpperCase());
 }
 
+function getExtensionName(pkgInfo) {
+  if (pkgInfo.config && pkgInfo.config.game) {
+    return `Game: ${pkgInfo.config.game}`;
+  }
+  if (pkgInfo.config && pkgInfo.config.extensionName) {
+    return pkgInfo.config.extensionName;
+  }
+  return transformName(pkgInfo.name);
+}
+
 /**
  * function intended to be run during build of an extension,
  * extracting details about it from its package.json
@@ -17,7 +27,7 @@ function extractExtensionInfo(extPath) {
   const pkgInfo = JSON.parse(fs.readFileSync(path.join(extPath, 'package.json')).toString());
 
   return {
-    name: (pkgInfo.config && pkgInfo.config.game) ? `Game: ${pkgInfo.config.game}` : transformName(pkgInfo.name),
+    name: getExtensionName(pkgInfo),
     namespace: (pkgInfo.config && pkgInfo.config.namespace) ? pkgInfo.config.namespace : undefined,
     author: pkgInfo.author,
     version: pkgInfo.version,


### PR DESCRIPTION
Just adding another option for using `config.extensionName` to completely control the extension name's extraction logic, this time for non-game extensions to not have to abuse the `-`-to-space behaviour of `transformName`.

I also rolled in the earlier `config.game` logic into a function to make things a little clearer (but less terse).

Let me know if you have any feedback or anything.