### PR TITLE
fix: export webpack helper subpath

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,12 @@
   "exports": {
     ".": {
       "types": "./lib/api.d.ts"
+    },
+    "./bin/webpack": {
+      "require": "./bin/webpack.js"
+    },
+    "./bin/webpack.js": {
+      "require": "./bin/webpack.js"
     }
   },
   "bin": {


### PR DESCRIPTION
Fixes #60.

## What changed

- Exported the packaged webpack helper at `vortex-api/bin/webpack`.
- Also exported the explicit `vortex-api/bin/webpack.js` subpath for consumers that include the extension.

The helper is already included in the npm package via `files: ["./bin", ...]` and the migration guide still documents the webpack helper path, but the v2 export map only exposed the root typing entrypoint. That makes Node reject existing webpack configs with `ERR_PACKAGE_PATH_NOT_EXPORTED`.

## Validation

Before this change, this fails with `ERR_PACKAGE_PATH_NOT_EXPORTED`:

```sh
node -e "require.resolve('vortex-api/bin/webpack', { paths: [process.cwd()] })"
```

After this change, these pass:

```sh
node -e "console.log(require.resolve('vortex-api/bin/webpack', { paths: [process.cwd()] }))"
node -e "console.log(require.resolve('vortex-api/bin/webpack.js', { paths: [process.cwd()] }))"
node -e "const webpack=require('vortex-api/bin/webpack').default; console.log(typeof webpack);"
npm pack --dry-run
```